### PR TITLE
[HotFix]: Change from type INT to BIGINT PartidaID in Table Partida -…

### DIFF
--- a/Pontiland/src/main/resources/SQL/DDL.sql
+++ b/Pontiland/src/main/resources/SQL/DDL.sql
@@ -41,7 +41,7 @@ CREATE TABLE Propiedad (
 
 -- Tabla Partida (Representación de la partida en la base de datos)
 CREATE TABLE Partida (
-    PartidaID INT PRIMARY KEY,
+    PartidaID BIGINT PRIMARY KEY,
     Activa BOOLEAN NOT NULL DEFAULT TRUE,
     NumeroJugadores INT NOT NULL CHECK (NumeroJugadores BETWEEN 2 AND 4)
 );


### PR DESCRIPTION
Corrección realizada para la tabla Partida. El tipo del atributo PartidaID cambia de INT a BIGINT (equivalente a Long en Java) para permitir la inserción de fechas con formato _"yyyyMMddHHmmss"_ .